### PR TITLE
Null I18n

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,3 +114,65 @@ en:
         until: '%{rest} %{current}'
         count: '%{rest} %{current}'
         default: '%{rest} %{current}'
+
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/ice_cube.gemspec
+++ b/ice_cube.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 2.12.0')
   s.add_development_dependency('activesupport', '>= 3.0.0')
   s.add_development_dependency('tzinfo')
-  s.add_runtime_dependency('i18n')
+  s.add_development_dependency('i18n')
 end

--- a/lib/ice_cube.rb
+++ b/lib/ice_cube.rb
@@ -1,8 +1,8 @@
 require 'date'
 require 'ice_cube/deprecated'
-require 'i18n'
+require 'ice_cube/i18n'
 
-I18n.load_path += Dir[File.expand_path('../../config/locales/*{rb,yml}', __FILE__)]
+IceCube::I18n.detect_backend!
 
 module IceCube
 
@@ -71,7 +71,7 @@ module IceCube
   # Defines the format used by IceCube when printing out Schedule#to_s.
   # Defaults to '%B %e, %Y'
   def self.to_s_time_format
-    I18n.t("ice_cube.date.formats.default")
+    IceCube::I18n.t("ice_cube.date.formats.default")
   end
 
   # Sets the format used by IceCube when printing out Schedule#to_s.

--- a/lib/ice_cube/builders/ical_builder.rb
+++ b/lib/ice_cube/builders/ical_builder.rb
@@ -32,15 +32,15 @@ module IceCube
 
     def self.ical_utc_format(time)
       time = time.dup.utc
-      I18n.l(time, format: '%Y%m%dT%H%M%SZ') # utc time
+      IceCube::I18n.l(time, format: '%Y%m%dT%H%M%SZ') # utc time
     end
 
     def self.ical_format(time, force_utc)
       time = time.dup.utc if force_utc
       if time.utc?
-        ":#{I18n.l(time, format: '%Y%m%dT%H%M%SZ')}" # utc time
+        ":#{IceCube::I18n.l(time, format: '%Y%m%dT%H%M%SZ')}" # utc time
       else
-        ";TZID=#{I18n.l(time, format: '%Z:%Y%m%dT%H%M%S')}" # local time specified
+        ";TZID=#{IceCube::I18n.l(time, format: '%Z:%Y%m%dT%H%M%S')}" # local time specified
       end
     end
 

--- a/lib/ice_cube/builders/string_builder.rb
+++ b/lib/ice_cube/builders/string_builder.rb
@@ -21,8 +21,8 @@ module IceCube
           next if segments.empty?
           current = self.class.sentence(segments)
         end
-        f = I18n.t('ice_cube.string.format')[type] ? type : 'default'
-        string = I18n.t("ice_cube.string.format.#{f}", rest: string, current: current)
+        f = IceCube::I18n.t('ice_cube.string.format')[type] ? type : 'default'
+        string = IceCube::I18n.t("ice_cube.string.format.#{f}", rest: string, current: current)
       end
       string
     end
@@ -43,8 +43,8 @@ module IceCube
         case array.length
         when 0 ; ''
         when 1 ; array[0].to_s
-        when 2 ; "#{array[0]}#{I18n.t('ice_cube.array.two_words_connector')}#{array[1]}"
-        else ; "#{array[0...-1].join(I18n.t('ice_cube.array.words_connector'))}#{I18n.t('ice_cube.array.last_word_connector')}#{array[-1]}"
+        when 2 ; "#{array[0]}#{IceCube::I18n.t('ice_cube.array.two_words_connector')}#{array[1]}"
+        else ; "#{array[0...-1].join(IceCube::I18n.t('ice_cube.array.words_connector'))}#{IceCube::I18n.t('ice_cube.array.last_word_connector')}#{array[-1]}"
         end
       end
 
@@ -53,18 +53,18 @@ module IceCube
       end
 
       def ordinalize(number)
-        I18n.t('ice_cube.integer.ordinal', number: number, ordinal: ordinal(number))
+        IceCube::I18n.t('ice_cube.integer.ordinal', number: number, ordinal: ordinal(number))
       end
 
       def literal_ordinal(number)
-        I18n.t("ice_cube.integer.literal_ordinals")[number]
+        IceCube::I18n.t("ice_cube.integer.literal_ordinals")[number]
       end
 
       def ordinal(number)
-        ord = I18n.t("ice_cube.integer.ordinals")[number] ||
-          I18n.t("ice_cube.integer.ordinals")[number % 10] ||
-          I18n.t('ice_cube.integer.ordinals')[:default]
-        number >= 0 ? ord : I18n.t("ice_cube.integer.negative", ordinal: ord)
+        ord = IceCube::I18n.t("ice_cube.integer.ordinals")[number] ||
+          IceCube::I18n.t("ice_cube.integer.ordinals")[number % 10] ||
+          IceCube::I18n.t('ice_cube.integer.ordinals')[:default]
+        number >= 0 ? ord : IceCube::I18n.t("ice_cube.integer.negative", ordinal: ord)
       end
 
     end

--- a/lib/ice_cube/i18n.rb
+++ b/lib/ice_cube/i18n.rb
@@ -1,0 +1,24 @@
+module IceCube
+  module I18n
+    def self.t(*args)
+      backend.t(*args)
+    end
+
+    def self.l(*args)
+      backend.l(*args)
+    end
+
+    def self.backend
+      @backend
+    end
+
+    def self.detect_backend!
+      require 'i18n'
+      ::I18n.load_path += Dir[File.expand_path('../../../config/locales/*{rb,yml}', __FILE__)]
+      @backend = ::I18n
+    rescue LoadError
+      require 'ice_cube/null_i18n'
+      @backend = NullI18n
+    end
+  end
+end

--- a/lib/ice_cube/null_i18n.rb
+++ b/lib/ice_cube/null_i18n.rb
@@ -1,0 +1,28 @@
+require 'yaml'
+
+module IceCube
+  module NullI18n
+    def self.t(key, options = {})
+      base = key.to_s.split('.').reduce(config) { |hash, current_key| hash[current_key] }
+
+      base = base[options[:count] == 1 ? "one" : "other"] if options[:count]
+
+      if base.is_a?(Hash)
+        return base.each_with_object({}) do |(key, value), hash|
+          hash[key.is_a?(String) ? key.to_sym : key] = value
+        end
+      end
+
+      options.reduce(base) { |result, (find, replace)| result.gsub("%{#{find}}", "#{replace}") }
+    end
+
+    def self.l(date_or_time, options = {})
+      return date_or_time.strftime(options[:format]) if options[:format]
+      date_or_time.strftime(t('ice_cube.date.formats.default'))
+    end
+
+    def self.config
+      @config ||= YAML.load(File.read(File.join(File.dirname(__FILE__), '..', '..', 'config', 'locales', 'en.yml')))['en']
+    end
+  end
+end

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -313,14 +313,14 @@ module IceCube
     def to_s
       pieces = []
       rd = recurrence_times_with_start_time - extimes
-      pieces.concat rd.sort.map { |t| I18n.l(t, format: IceCube.to_s_time_format) }
+      pieces.concat rd.sort.map { |t| IceCube::I18n.l(t, format: IceCube.to_s_time_format) }
       pieces.concat rrules.map  { |t| t.to_s }
-      pieces.concat exrules.map { |t| I18n.t('ice_cube.not', target: t.to_s) }
+      pieces.concat exrules.map { |t| IceCube::I18n.t('ice_cube.not', target: t.to_s) }
       pieces.concat extimes.sort.map { |t|
-        target = I18n.l(t, format: IceCube.to_s_time_format)
-        I18n.t('ice_cube.not_on', target: target)
+        target = IceCube::I18n.l(t, format: IceCube.to_s_time_format)
+        IceCube::I18n.t('ice_cube.not_on', target: target)
       }
-      pieces.join(I18n.t('ice_cube.pieces_connector'))
+      pieces.join(IceCube::I18n.t('ice_cube.pieces_connector'))
     end
 
     # Serialize this schedule to_ical

--- a/lib/ice_cube/validations/count.rb
+++ b/lib/ice_cube/validations/count.rb
@@ -51,7 +51,7 @@ module IceCube
 
       StringBuilder.register_formatter(:count) do |segments|
         count = segments.first
-        I18n.t('ice_cube.times', count: count)
+        IceCube::I18n.t('ice_cube.times', count: count)
       end
 
     end

--- a/lib/ice_cube/validations/daily_interval.rb
+++ b/lib/ice_cube/validations/daily_interval.rb
@@ -35,7 +35,7 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.base = I18n.t('ice_cube.each_day', count: interval)
+        builder.base = IceCube::I18n.t('ice_cube.each_day', count: interval)
       end
 
       def build_hash(builder)

--- a/lib/ice_cube/validations/day.rb
+++ b/lib/ice_cube/validations/day.rb
@@ -54,13 +54,13 @@ module IceCube
         validation_days.sort!
         # pick the right shortening, if applicable
         if validation_days == [0, 6]
-          I18n.t('ice_cube.on_weekends')
+          IceCube::I18n.t('ice_cube.on_weekends')
         elsif validation_days == (1..5).to_a
-          I18n.t('ice_cube.on_weekdays')
+          IceCube::I18n.t('ice_cube.on_weekdays')
         else
-          day_names = ->(d){ "#{I18n.t("ice_cube.days_on")[d]}" }
+          day_names = ->(d){ "#{IceCube::I18n.t("ice_cube.days_on")[d]}" }
           segments = validation_days.map(&day_names)
-          I18n.t('ice_cube.on_days', days: StringBuilder.sentence(segments))
+          IceCube::I18n.t('ice_cube.on_days', days: StringBuilder.sentence(segments))
         end
       end
 

--- a/lib/ice_cube/validations/day_of_month.rb
+++ b/lib/ice_cube/validations/day_of_month.rb
@@ -44,8 +44,8 @@ module IceCube
 
       StringBuilder.register_formatter(:day_of_month) do |entries|
         sentence = StringBuilder.sentence(entries)
-        str = I18n.t('ice_cube.days_of_month', count: entries.size, segments: sentence)
-        I18n.t('ice_cube.on', sentence: str)
+        str = IceCube::I18n.t('ice_cube.days_of_month', count: entries.size, segments: sentence)
+        IceCube::I18n.t('ice_cube.on', sentence: str)
       end
 
     end

--- a/lib/ice_cube/validations/day_of_week.rb
+++ b/lib/ice_cube/validations/day_of_week.rb
@@ -45,10 +45,10 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.piece(:day_of_week) << I18n.t(
+        builder.piece(:day_of_week) << IceCube::I18n.t(
           'ice_cube.days_of_week',
           segments: StringBuilder.nice_number(occ),
-          day: I18n.t('ice_cube.date.day_names')[day]
+          day: IceCube::I18n.t('ice_cube.date.day_names')[day]
         )
       end
 
@@ -66,8 +66,8 @@ module IceCube
       end
 
       StringBuilder.register_formatter(:day_of_week) do |segments|
-        sentence = segments.join(I18n.t('ice_cube.array.two_words_connector'))
-        I18n.t('ice_cube.on', sentence: sentence)
+        sentence = segments.join(IceCube::I18n.t('ice_cube.array.two_words_connector'))
+        IceCube::I18n.t('ice_cube.on', sentence: sentence)
       end
 
     end

--- a/lib/ice_cube/validations/day_of_year.rb
+++ b/lib/ice_cube/validations/day_of_year.rb
@@ -50,8 +50,8 @@ module IceCube
 
       StringBuilder.register_formatter(:day_of_year) do |entries|
         str =  StringBuilder.sentence(entries)
-        sentence = I18n.t('ice_cube.days_of_year', count: entries.size, segments: str)
-        I18n.t('ice_cube.on', sentence: sentence)
+        sentence = IceCube::I18n.t('ice_cube.days_of_year', count: entries.size, segments: str)
+        IceCube::I18n.t('ice_cube.on', sentence: sentence)
       end
 
     end

--- a/lib/ice_cube/validations/hour_of_day.rb
+++ b/lib/ice_cube/validations/hour_of_day.rb
@@ -45,7 +45,7 @@ module IceCube
 
       StringBuilder.register_formatter(:hour_of_day) do |segments|
         str = StringBuilder.sentence(segments)
-        I18n.t('ice_cube.at_hours_of_the_day', count: segments.size, segments: str)
+        IceCube::I18n.t('ice_cube.at_hours_of_the_day', count: segments.size, segments: str)
       end
 
     end

--- a/lib/ice_cube/validations/hourly_interval.rb
+++ b/lib/ice_cube/validations/hourly_interval.rb
@@ -35,7 +35,7 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.base = I18n.t("ice_cube.each_hour", count: interval)
+        builder.base = IceCube::I18n.t("ice_cube.each_hour", count: interval)
       end
 
       def build_hash(builder)

--- a/lib/ice_cube/validations/minute_of_hour.rb
+++ b/lib/ice_cube/validations/minute_of_hour.rb
@@ -44,7 +44,7 @@ module IceCube
 
       StringBuilder.register_formatter(:minute_of_hour) do |segments|
         str = StringBuilder.sentence(segments)
-        I18n.t('ice_cube.on_minutes_of_hour', count: segments.size, segments: str)
+        IceCube::I18n.t('ice_cube.on_minutes_of_hour', count: segments.size, segments: str)
       end
 
     end

--- a/lib/ice_cube/validations/minutely_interval.rb
+++ b/lib/ice_cube/validations/minutely_interval.rb
@@ -35,7 +35,7 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.base = I18n.t('ice_cube.each_minute', count: interval)
+        builder.base = IceCube::I18n.t('ice_cube.each_minute', count: interval)
       end
 
       def build_hash(builder)

--- a/lib/ice_cube/validations/month_of_year.rb
+++ b/lib/ice_cube/validations/month_of_year.rb
@@ -32,7 +32,7 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.piece(:month_of_year) << I18n.t("ice_cube.date.month_names")[month]
+        builder.piece(:month_of_year) << IceCube::I18n.t("ice_cube.date.month_names")[month]
       end
 
       def build_hash(builder)
@@ -44,7 +44,7 @@ module IceCube
       end
 
       StringBuilder.register_formatter(:month_of_year) do |segments|
-        I18n.t("ice_cube.in", target: StringBuilder.sentence(segments))
+        IceCube::I18n.t("ice_cube.in", target: StringBuilder.sentence(segments))
       end
 
     end

--- a/lib/ice_cube/validations/monthly_interval.rb
+++ b/lib/ice_cube/validations/monthly_interval.rb
@@ -34,7 +34,7 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.base = I18n.t('ice_cube.each_month', count: interval)
+        builder.base = IceCube::I18n.t('ice_cube.each_month', count: interval)
       end
 
       def build_hash(builder)

--- a/lib/ice_cube/validations/second_of_minute.rb
+++ b/lib/ice_cube/validations/second_of_minute.rb
@@ -44,7 +44,7 @@ module IceCube
 
       StringBuilder.register_formatter(:second_of_minute) do |segments|
         str = StringBuilder.sentence(segments)
-        I18n.t('ice_cube.on_seconds_of_minute', count: segments.size, segments: str)
+        IceCube::I18n.t('ice_cube.on_seconds_of_minute', count: segments.size, segments: str)
       end
 
     end

--- a/lib/ice_cube/validations/secondly_interval.rb
+++ b/lib/ice_cube/validations/secondly_interval.rb
@@ -32,7 +32,7 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.base = I18n.t("ice_cube.each_second", count: interval)
+        builder.base = IceCube::I18n.t("ice_cube.each_second", count: interval)
       end
 
       def build_hash(builder)

--- a/lib/ice_cube/validations/until.rb
+++ b/lib/ice_cube/validations/until.rb
@@ -38,8 +38,8 @@ module IceCube
       end
 
       def build_s(builder)
-        date = I18n.l(time, format: IceCube.to_s_time_format)
-        builder.piece(:until) << I18n.t('ice_cube.until', date: date)
+        date = IceCube::I18n.l(time, format: IceCube.to_s_time_format)
+        builder.piece(:until) << IceCube::I18n.t('ice_cube.until', date: date)
       end
 
       def build_hash(builder)

--- a/lib/ice_cube/validations/weekly_interval.rb
+++ b/lib/ice_cube/validations/weekly_interval.rb
@@ -44,7 +44,7 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.base = I18n.t('ice_cube.each_week', count: interval)
+        builder.base = IceCube::I18n.t('ice_cube.each_week', count: interval)
       end
 
       def build_hash(builder)

--- a/lib/ice_cube/validations/yearly_interval.rb
+++ b/lib/ice_cube/validations/yearly_interval.rb
@@ -32,7 +32,7 @@ module IceCube
       end
 
       def build_s(builder)
-        builder.base = I18n.t('ice_cube.each_year', count: interval)
+        builder.base = IceCube::I18n.t('ice_cube.each_year', count: interval)
       end
 
       def build_hash(builder)

--- a/spec/examples/to_s_en_spec.rb
+++ b/spec/examples/to_s_en_spec.rb
@@ -1,206 +1,224 @@
 require File.dirname(__FILE__) + '/../spec_helper'
+require 'i18n'
+require 'ice_cube/null_i18n'
 
 describe IceCube::Schedule, 'to_s' do
 
-  before :each do
-    I18n.locale = :en
+  shared_examples "to_s in English" do
+
+    it 'should represent its start time by default' do
+      t0 = Time.local(2013, 2, 14)
+      IceCube::Schedule.new(t0).to_s.should == 'February 14, 2013'
+    end
+
+    it 'should have a useful base to_s representation for a secondly rule' do
+      IceCube::Rule.secondly.to_s.should == 'Secondly'
+      IceCube::Rule.secondly(2).to_s.should == 'Every 2 seconds'
+    end
+
+    it 'should have a useful base to_s representation for a minutely rule' do
+      IceCube::Rule.minutely.to_s.should == 'Minutely'
+      IceCube::Rule.minutely(2).to_s.should == 'Every 2 minutes'
+    end
+
+    it 'should have a useful base to_s representation for a hourly rule' do
+      IceCube::Rule.hourly.to_s.should == 'Hourly'
+      IceCube::Rule.hourly(2).to_s.should == 'Every 2 hours'
+    end
+
+    it 'should have a useful base to_s representation for a daily rule' do
+      IceCube::Rule.daily.to_s.should == 'Daily'
+      IceCube::Rule.daily(2).to_s.should == 'Every 2 days'
+    end
+
+    it 'should have a useful base to_s representation for a weekly rule' do
+      IceCube::Rule.weekly.to_s.should == 'Weekly'
+      IceCube::Rule.weekly(2).to_s.should == 'Every 2 weeks'
+    end
+
+    it 'should have a useful base to_s representation for a monthly rule' do
+      IceCube::Rule.monthly.to_s.should == 'Monthly'
+      IceCube::Rule.monthly(2).to_s.should == 'Every 2 months'
+    end
+
+    it 'should have a useful base to_s representation for a yearly rule' do
+      IceCube::Rule.yearly.to_s.should == 'Yearly'
+      IceCube::Rule.yearly(2).to_s.should == 'Every 2 years'
+    end
+
+    it 'should work with various sentence types properly' do
+      IceCube::Rule.weekly.to_s.should == 'Weekly'
+      IceCube::Rule.weekly.day(:monday).to_s.should == 'Weekly on Mondays'
+      IceCube::Rule.weekly.day(:monday, :tuesday).to_s.should == 'Weekly on Mondays and Tuesdays'
+      IceCube::Rule.weekly.day(:monday, :tuesday, :wednesday).to_s.should == 'Weekly on Mondays, Tuesdays, and Wednesdays'
+    end
+
+    it 'should show saturday and sunday as weekends' do
+      IceCube::Rule.weekly.day(:saturday, :sunday).to_s.should == 'Weekly on Weekends'
+    end
+
+    it 'should not show saturday and sunday as weekends when other days are present also' do
+      IceCube::Rule.weekly.day(:sunday, :monday, :saturday).to_s.should ==
+        'Weekly on Sundays, Mondays, and Saturdays'
+    end
+
+    it 'should reorganize days to be in order' do
+      IceCube::Rule.weekly.day(:tuesday, :monday).to_s.should ==
+        'Weekly on Mondays and Tuesdays'
+    end
+
+    it 'should show weekdays as such' do
+      IceCube::Rule.weekly.day(
+        :monday, :tuesday, :wednesday,
+        :thursday, :friday
+      ).to_s.should == 'Weekly on Weekdays'
+    end
+
+    it 'should not show weekdays as such when a weekend day is present' do
+      IceCube::Rule.weekly.day(
+        :sunday, :monday, :tuesday, :wednesday,
+        :thursday, :friday
+      ).to_s.should == 'Weekly on Sundays, Mondays, Tuesdays, Wednesdays, Thursdays, and Fridays'
+    end
+
+    it 'should show start time for an empty schedule' do
+      schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
+      schedule.to_s.should == "March 20, 2010"
+    end
+
+    it 'should work with a single date' do
+      schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
+      schedule.add_recurrence_time Time.local(2010, 3, 20)
+      schedule.to_s.should == "March 20, 2010"
+    end
+
+    it 'should work with additional dates' do
+      schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
+      schedule.add_recurrence_time Time.local(2010, 3, 20)
+      schedule.add_recurrence_time Time.local(2010, 3, 21)
+      schedule.to_s.should == 'March 20, 2010 / March 21, 2010'
+    end
+
+    it 'should order dates that are out of order' do
+      schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
+      schedule.add_recurrence_time Time.local(2010, 3, 19)
+      schedule.to_s.should == 'March 19, 2010 / March 20, 2010'
+    end
+
+    it 'should remove duplicated start time' do
+      schedule = IceCube::Schedule.new t0 = Time.local(2010, 3, 20)
+      schedule.add_recurrence_time t0
+      schedule.to_s.should == 'March 20, 2010'
+    end
+
+    it 'should remove duplicate rtimes' do
+      schedule = IceCube::Schedule.new Time.local(2010, 3, 19)
+      schedule.add_recurrence_time Time.local(2010, 3, 20)
+      schedule.add_recurrence_time Time.local(2010, 3, 20)
+      schedule.to_s.should == 'March 19, 2010 / March 20, 2010'
+    end
+
+    it 'should work with rules and dates' do
+      schedule = IceCube::Schedule.new Time.local(2010, 3, 19)
+      schedule.add_recurrence_time Time.local(2010, 3, 20)
+      schedule.add_recurrence_rule IceCube::Rule.weekly
+      schedule.to_s.should == 'March 20, 2010 / Weekly'
+    end
+
+    it 'should work with rules and times and exception times' do
+      schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
+      schedule.add_recurrence_rule IceCube::Rule.weekly
+      schedule.add_recurrence_time Time.local(2010, 3, 20)
+      schedule.add_exception_time Time.local(2010, 3, 20) # ignored
+      schedule.add_exception_time Time.local(2010, 3, 21)
+      schedule.to_s.should == 'Weekly / not on March 20, 2010 / not on March 21, 2010'
+    end
+
+    it 'should work with a single rrule' do
+      schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
+      schedule.add_recurrence_rule IceCube::Rule.weekly.day_of_week(:monday => [1])
+      schedule.to_s.should == schedule.rrules[0].to_s
+    end
+
+    it 'should be able to say the last Thursday of the month' do
+      rule_str = IceCube::Rule.monthly.day_of_week(:thursday => [-1]).to_s
+      rule_str.should == 'Monthly on the last Thursday'
+    end
+
+    it 'should be able to say what months of the year something happens' do
+      rule_str = IceCube::Rule.yearly.month_of_year(:june, :july).to_s
+      rule_str.should == 'Yearly in June and July'
+    end
+
+    it 'should be able to say the second to last monday of the month' do
+      rule_str = IceCube::Rule.monthly.day_of_week(:thursday => [-2]).to_s
+      rule_str.should == 'Monthly on the 2nd to last Thursday'
+    end
+
+    it 'should join the first and last weekdays of the month' do
+      rule_str = IceCube::Rule.monthly.day_of_week(:thursday => [1, -1]).to_s
+      rule_str.should == 'Monthly on the 1st Thursday and last Thursday'
+    end
+
+    it 'should be able to say the days of the month something happens' do
+      rule_str = IceCube::Rule.monthly.day_of_month(1, 15, 30).to_s
+      rule_str.should == 'Monthly on the 1st, 15th, and 30th days of the month'
+    end
+
+    it 'should be able to say what day of the year something happens' do
+      rule_str = IceCube::Rule.yearly.day_of_year(30).to_s
+      rule_str.should == 'Yearly on the 30th day of the year'
+    end
+
+    it 'should be able to say what hour of the day something happens' do
+      rule_str = IceCube::Rule.daily.hour_of_day(6, 12).to_s
+      rule_str.should == 'Daily on the 6th and 12th hours of the day'
+    end
+
+    it 'should be able to say what minute of an hour something happens - with special suffix minutes' do
+      rule_str = IceCube::Rule.hourly.minute_of_hour(10, 11, 12, 13, 14, 15).to_s
+      rule_str.should == 'Hourly on the 10th, 11th, 12th, 13th, 14th, and 15th minutes of the hour'
+    end
+
+    it 'should be able to say what seconds of the minute something happens' do
+      rule_str = IceCube::Rule.minutely.second_of_minute(10, 11).to_s
+      rule_str.should == 'Minutely on the 10th and 11th seconds of the minute'
+    end
+
+    it 'should be able to reflect until dates' do
+      schedule = IceCube::Schedule.new(Time.now)
+      schedule.rrule IceCube::Rule.weekly.until(Time.local(2012, 2, 3))
+      schedule.to_s.should == 'Weekly until February 3, 2012'
+    end
+
+    it 'should be able to reflect count' do
+      schedule = IceCube::Schedule.new(Time.now)
+      schedule.add_recurrence_rule IceCube::Rule.weekly.count(1)
+      schedule.to_s.should == 'Weekly 1 time'
+    end
+
+    it 'should be able to reflect count (proper pluralization)' do
+      schedule = IceCube::Schedule.new(Time.now)
+      schedule.add_recurrence_rule IceCube::Rule.weekly.count(2)
+      schedule.to_s.should == 'Weekly 2 times'
+    end
+
   end
 
-  it 'should represent its start time by default' do
-    t0 = Time.local(2013, 2, 14)
-    IceCube::Schedule.new(t0).to_s.should == 'February 14, 2013'
+  context "without I18n" do
+    before { IceCube::I18n.stub(:backend) { IceCube::NullI18n } }
+
+    it_behaves_like "to_s in English"
   end
 
-  it 'should have a useful base to_s representation for a secondly rule' do
-    IceCube::Rule.secondly.to_s.should == 'Secondly'
-    IceCube::Rule.secondly(2).to_s.should == 'Every 2 seconds'
-  end
+  context "with I18n" do
+    before(:each) { I18n.locale = :en }
 
-  it 'should have a useful base to_s representation for a minutely rule' do
-    IceCube::Rule.minutely.to_s.should == 'Minutely'
-    IceCube::Rule.minutely(2).to_s.should == 'Every 2 minutes'
-  end
+    it "uses I18n" do
+      IceCube::I18n.backend.should == I18n
+    end
 
-  it 'should have a useful base to_s representation for a hourly rule' do
-    IceCube::Rule.hourly.to_s.should == 'Hourly'
-    IceCube::Rule.hourly(2).to_s.should == 'Every 2 hours'
-  end
-
-  it 'should have a useful base to_s representation for a daily rule' do
-    IceCube::Rule.daily.to_s.should == 'Daily'
-    IceCube::Rule.daily(2).to_s.should == 'Every 2 days'
-  end
-
-  it 'should have a useful base to_s representation for a weekly rule' do
-    IceCube::Rule.weekly.to_s.should == 'Weekly'
-    IceCube::Rule.weekly(2).to_s.should == 'Every 2 weeks'
-  end
-
-  it 'should have a useful base to_s representation for a monthly rule' do
-    IceCube::Rule.monthly.to_s.should == 'Monthly'
-    IceCube::Rule.monthly(2).to_s.should == 'Every 2 months'
-  end
-
-  it 'should have a useful base to_s representation for a yearly rule' do
-    IceCube::Rule.yearly.to_s.should == 'Yearly'
-    IceCube::Rule.yearly(2).to_s.should == 'Every 2 years'
-  end
-
-  it 'should work with various sentence types properly' do
-    IceCube::Rule.weekly.to_s.should == 'Weekly'
-    IceCube::Rule.weekly.day(:monday).to_s.should == 'Weekly on Mondays'
-    IceCube::Rule.weekly.day(:monday, :tuesday).to_s.should == 'Weekly on Mondays and Tuesdays'
-    IceCube::Rule.weekly.day(:monday, :tuesday, :wednesday).to_s.should == 'Weekly on Mondays, Tuesdays, and Wednesdays'
-  end
-
-  it 'should show saturday and sunday as weekends' do
-    IceCube::Rule.weekly.day(:saturday, :sunday).to_s.should == 'Weekly on Weekends'
-  end
-
-  it 'should not show saturday and sunday as weekends when other days are present also' do
-    IceCube::Rule.weekly.day(:sunday, :monday, :saturday).to_s.should ==
-      'Weekly on Sundays, Mondays, and Saturdays'
-  end
-
-  it 'should reorganize days to be in order' do
-    IceCube::Rule.weekly.day(:tuesday, :monday).to_s.should ==
-      'Weekly on Mondays and Tuesdays'
-  end
-
-  it 'should show weekdays as such' do
-    IceCube::Rule.weekly.day(
-      :monday, :tuesday, :wednesday,
-      :thursday, :friday
-    ).to_s.should == 'Weekly on Weekdays'
-  end
-
-  it 'should not show weekdays as such when a weekend day is present' do
-    IceCube::Rule.weekly.day(
-      :sunday, :monday, :tuesday, :wednesday,
-      :thursday, :friday
-    ).to_s.should == 'Weekly on Sundays, Mondays, Tuesdays, Wednesdays, Thursdays, and Fridays'
-  end
-
-  it 'should show start time for an empty schedule' do
-    schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
-    schedule.to_s.should == "March 20, 2010"
-  end
-
-  it 'should work with a single date' do
-    schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
-    schedule.add_recurrence_time Time.local(2010, 3, 20)
-    schedule.to_s.should == "March 20, 2010"
-  end
-
-  it 'should work with additional dates' do
-    schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
-    schedule.add_recurrence_time Time.local(2010, 3, 20)
-    schedule.add_recurrence_time Time.local(2010, 3, 21)
-    schedule.to_s.should == 'March 20, 2010 / March 21, 2010'
-  end
-
-  it 'should order dates that are out of order' do
-    schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
-    schedule.add_recurrence_time Time.local(2010, 3, 19)
-    schedule.to_s.should == 'March 19, 2010 / March 20, 2010'
-  end
-
-  it 'should remove duplicated start time' do
-    schedule = IceCube::Schedule.new t0 = Time.local(2010, 3, 20)
-    schedule.add_recurrence_time t0
-    schedule.to_s.should == 'March 20, 2010'
-  end
-
-  it 'should remove duplicate rtimes' do
-    schedule = IceCube::Schedule.new Time.local(2010, 3, 19)
-    schedule.add_recurrence_time Time.local(2010, 3, 20)
-    schedule.add_recurrence_time Time.local(2010, 3, 20)
-    schedule.to_s.should == 'March 19, 2010 / March 20, 2010'
-  end
-
-  it 'should work with rules and dates' do
-    schedule = IceCube::Schedule.new Time.local(2010, 3, 19)
-    schedule.add_recurrence_time Time.local(2010, 3, 20)
-    schedule.add_recurrence_rule IceCube::Rule.weekly
-    schedule.to_s.should == 'March 20, 2010 / Weekly'
-  end
-
-  it 'should work with rules and times and exception times' do
-    schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
-    schedule.add_recurrence_rule IceCube::Rule.weekly
-    schedule.add_recurrence_time Time.local(2010, 3, 20)
-    schedule.add_exception_time Time.local(2010, 3, 20) # ignored
-    schedule.add_exception_time Time.local(2010, 3, 21)
-    schedule.to_s.should == 'Weekly / not on March 20, 2010 / not on March 21, 2010'
-  end
-
-  it 'should work with a single rrule' do
-    schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
-    schedule.add_recurrence_rule IceCube::Rule.weekly.day_of_week(:monday => [1])
-    schedule.to_s.should == schedule.rrules[0].to_s
-  end
-
-  it 'should be able to say the last Thursday of the month' do
-    rule_str = IceCube::Rule.monthly.day_of_week(:thursday => [-1]).to_s
-    rule_str.should == 'Monthly on the last Thursday'
-  end
-
-  it 'should be able to say what months of the year something happens' do
-    rule_str = IceCube::Rule.yearly.month_of_year(:june, :july).to_s
-    rule_str.should == 'Yearly in June and July'
-  end
-
-  it 'should be able to say the second to last monday of the month' do
-    rule_str = IceCube::Rule.monthly.day_of_week(:thursday => [-2]).to_s
-    rule_str.should == 'Monthly on the 2nd to last Thursday'
-  end
-
-  it 'should join the first and last weekdays of the month' do
-    rule_str = IceCube::Rule.monthly.day_of_week(:thursday => [1, -1]).to_s
-    rule_str.should == 'Monthly on the 1st Thursday and last Thursday'
-  end
-
-  it 'should be able to say the days of the month something happens' do
-    rule_str = IceCube::Rule.monthly.day_of_month(1, 15, 30).to_s
-    rule_str.should == 'Monthly on the 1st, 15th, and 30th days of the month'
-  end
-
-  it 'should be able to say what day of the year something happens' do
-    rule_str = IceCube::Rule.yearly.day_of_year(30).to_s
-    rule_str.should == 'Yearly on the 30th day of the year'
-  end
-
-  it 'should be able to say what hour of the day something happens' do
-    rule_str = IceCube::Rule.daily.hour_of_day(6, 12).to_s
-    rule_str.should == 'Daily on the 6th and 12th hours of the day'
-  end
-
-  it 'should be able to say what minute of an hour something happens - with special suffix minutes' do
-    rule_str = IceCube::Rule.hourly.minute_of_hour(10, 11, 12, 13, 14, 15).to_s
-    rule_str.should == 'Hourly on the 10th, 11th, 12th, 13th, 14th, and 15th minutes of the hour'
-  end
-
-  it 'should be able to say what seconds of the minute something happens' do
-    rule_str = IceCube::Rule.minutely.second_of_minute(10, 11).to_s
-    rule_str.should == 'Minutely on the 10th and 11th seconds of the minute'
-  end
-
-  it 'should be able to reflect until dates' do
-    schedule = IceCube::Schedule.new(Time.now)
-    schedule.rrule IceCube::Rule.weekly.until(Time.local(2012, 2, 3))
-    schedule.to_s.should == 'Weekly until February 3, 2012'
-  end
-
-  it 'should be able to reflect count' do
-    schedule = IceCube::Schedule.new(Time.now)
-    schedule.add_recurrence_rule IceCube::Rule.weekly.count(1)
-    schedule.to_s.should == 'Weekly 1 time'
-  end
-
-  it 'should be able to reflect count (proper pluralization)' do
-    schedule = IceCube::Schedule.new(Time.now)
-    schedule.add_recurrence_rule IceCube::Rule.weekly.count(2)
-    schedule.to_s.should == 'Weekly 2 times'
+    it_behaves_like "to_s in English"
   end
 
 end


### PR DESCRIPTION
@dgilperez @avit this adds a wrapper around `I18n` (`IceCube::I18n`) which attempts to require in the real library, and delegate to that, but uses `IceCube::NullI18n` instead if that fails, which implements the very very basics of the real library's interpolation logic to get by. I don't hugely like it but it does get rid of the runtime dependency.
